### PR TITLE
Fixed Bug: Request filter screen not showing category in alert on submit

### DIFF
--- a/screens/AllRequests/ReqFilter.js
+++ b/screens/AllRequests/ReqFilter.js
@@ -26,19 +26,39 @@ const ReqFilter = () => {
   };
 
   const toggleCategory = (category) => {
+    console.log(category);
     if (category.subCategories) {
       setCurrentCategory(category);
       setSubCategoryModalVisible(true); // Open modal for subcategories
-    } else {
-      setSelectedCategories((prev) =>
-        prev.includes(category.name)
-          ? prev.filter((cat) => cat !== category.name)
-          : [...prev, category.name]
-      );
     }
+    
+    setSelectedCategories((prevState) =>
+      {
+        if (!prevState.includes(category.name)) {
+          return [...prevState, category.name];
+        }
+        return prevState;
+      }
+    );
   };
 
+  // when exiting from a subcategory list, check if any of the subcategories selected
+  // if not, remove category from the list in order to properly update incase subcategories removed or none selected
+  const checkToRemoveCategory = (category) => {
+    for (const sub of category.subCategories) {
+        if (selectedSubCategories.includes(sub)) {
+          return;
+        }
+    }
+    setSelectedCategories((prevState) =>
+    {
+      return prevState.filter((item) => item !== category.name);
+    }
+    );
+  }
+
   const toggleSubCategory = (subCategory) => {
+    console.log(subCategory);
     setSelectedSubCategories((prev) =>
       prev.includes(subCategory)
         ? prev.filter((item) => item !== subCategory)
@@ -205,7 +225,10 @@ const ReqFilter = () => {
             renderItem={renderSubCategory}
           />
           <TouchableOpacity
-            onPress={() => setSubCategoryModalVisible(false)}
+            onPress={() => {
+              setSubCategoryModalVisible(false);
+              checkToRemoveCategory(currentCategory);
+            }}
             style={styles.doneButton}
           >
             <Text style={styles.doneText}>Done</Text>

--- a/screens/AllRequests/ReqFilter.js
+++ b/screens/AllRequests/ReqFilter.js
@@ -26,7 +26,6 @@ const ReqFilter = () => {
   };
 
   const toggleCategory = (category) => {
-    console.log(category);
     if (category.subCategories) {
       setCurrentCategory(category);
       setSubCategoryModalVisible(true); // Open modal for subcategories
@@ -43,7 +42,7 @@ const ReqFilter = () => {
   };
 
   // when exiting from a subcategory list, check if any of the subcategories selected
-  // if not, remove category from the list in order to properly update incase subcategories removed or none selected
+  // if not, remove category from the list in order to properly update incasegu subcategories removed or none selected
   const checkToRemoveCategory = (category) => {
     for (const sub of category.subCategories) {
         if (selectedSubCategories.includes(sub)) {
@@ -58,7 +57,6 @@ const ReqFilter = () => {
   }
 
   const toggleSubCategory = (subCategory) => {
-    console.log(subCategory);
     setSelectedSubCategories((prev) =>
       prev.includes(subCategory)
         ? prev.filter((item) => item !== subCategory)


### PR DESCRIPTION
The alert pop-up message from applying request filters within "Others Requests" now properly displays the categories selected along with the subcategories and status. Closes #129 